### PR TITLE
fix: improve smoke test reliability and CI configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,7 +48,7 @@ export default [
     },
   },
   {
-    files: ["tests/**/*.js", "*.spec.js", "*.test.js"],
+    files: ["tests/**/*.js", "*.spec.js", "*.test.js", "playwright.config.js", "*.config.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.CI ? "https://synkope.github.io/synkope-website/" : "http://localhost:8000",
+    baseURL: "http://localhost:8000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -73,14 +73,12 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: process.env.CI
-    ? undefined
-    : {
-        command: "npm run serve",
-        url: "http://localhost:8000",
-        reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
-      },
+  webServer: {
+    command: "npm run serve",
+    url: "http://localhost:8000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
 
   /* Output directory for test artifacts */
   outputDir: "test-results/",

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -7,12 +7,10 @@ import { chromium } from "@playwright/test";
 async function globalSetup() {
   console.log("🚀 Starting global test setup...");
 
-  // Check if we're running in CI or local environment
-  const isCI = !!process.env.CI;
-  const baseURL = process.env.CI ? "https://synkope.github.io/synkope-website/" : "http://localhost:8000";
+  // Use localhost in all environments (webServer handles starting the dev server)
+  const baseURL = "http://localhost:8000";
 
   console.log(`📍 Testing against: ${baseURL}`);
-  console.log(`🔧 Environment: ${isCI ? "CI" : "Local Development"}`);
 
   // Launch a browser to verify the site is accessible
   const browser = await chromium.launch();
@@ -67,15 +65,7 @@ async function globalSetup() {
     }
   } catch (error) {
     console.error("❌ Global setup failed:", error.message);
-
-    if (isCI) {
-      // In CI, this might be expected if the site hasn't deployed yet
-      console.log("🔄 This might be expected in CI if deployment is still in progress");
-    } else {
-      // In local development, this is more serious
-      console.error('💡 Make sure you have started the local server with "npm run serve" or "make serve"');
-    }
-
+    console.error("💡 Make sure the server is running. Playwright should auto-start it via webServer config.");
     throw error;
   } finally {
     await page.close();
@@ -86,7 +76,6 @@ async function globalSetup() {
 
   return {
     baseURL,
-    isCI,
     setupTime: new Date().toISOString(),
   };
 }

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -57,7 +57,14 @@ test.describe("Smoke Tests - Critical Functionality", () => {
     await page.waitForLoadState("networkidle");
 
     // Allow some known errors but fail on critical ones
-    const criticalErrors = consoleErrors.filter((error) => !error.includes("favicon") && !error.includes("404"));
+    const criticalErrors = consoleErrors.filter(
+      (error) =>
+        !error.includes("favicon") &&
+        !error.includes("404") &&
+        !error.includes("X-Frame-Options") &&
+        !error.includes("Content Security Policy") &&
+        !error.includes("frame-ancestors"),
+    );
     expect(criticalErrors).toHaveLength(0);
   });
 });

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -40,9 +40,9 @@ test.describe("Smoke Tests - Critical Functionality", () => {
     const teamMembers = page.locator(".team-member");
     await expect(teamMembers).toHaveCount(4);
 
-    // Verify content is loaded from JSON (not default "Loading..." text)
-    const firstMemberDesc = await page.locator(".team-member").first().locator(".team-info p").textContent();
-    expect(firstMemberDesc).not.toContain("Loading...");
+    // Wait for content to load from JSON
+    const firstMemberDesc = page.locator(".team-member").first().locator(".team-info p");
+    await expect(firstMemberDesc).not.toHaveText("Loading...", { timeout: 10000 });
   });
 
   test("should load without console errors", async ({ page }) => {
@@ -63,7 +63,8 @@ test.describe("Smoke Tests - Critical Functionality", () => {
         !error.includes("404") &&
         !error.includes("X-Frame-Options") &&
         !error.includes("Content Security Policy") &&
-        !error.includes("frame-ancestors"),
+        !error.includes("frame-ancestors") &&
+        !error.includes("TLS handshake"),
     );
     expect(criticalErrors).toHaveLength(0);
   });


### PR DESCRIPTION
## Problem
Smoke tests were failing on Renovate PRs due to:
1. Tests trying to access GitHub Pages URL instead of local server in CI
2. Race condition where tests checked team content before JSON finished loading
3. Non-critical console errors (X-Frame-Options, CSP, TLS) causing test failures

## Solution

### 1. Configure tests to use local server in CI (`4ddbea1`)
- Update playwright.config.js to always use localhost:8000
- Enable webServer in CI to auto-start development server
- Simplify global-setup.js to remove GitHub Pages URL logic
- Tests now run against locally served content in all environments

### 2. Ignore non-critical console warnings (`cfeab8e`)
- Filter out X-Frame-Options and CSP warnings from meta tags
- These are browser warnings, not application errors
- Allows smoke tests to focus on real functionality issues

### 3. Wait for content to load in team members test (`c7b22a6`)
- Use `await expect` with 10s timeout instead of immediate check
- Fixes race condition where test runs before JSON content loads
- Also filter out TLS handshake errors (external font loading in WebKit)

## Benefits
- ✅ Smoke tests are more reliable and handle async content loading
- ✅ Tests run in consistent environment (local server) in both CI and dev
- ✅ Fewer false positives from non-critical browser warnings
- ✅ Should fix all failing Renovate PRs

## Testing
- Smoke tests pass locally
- Will verify on CI when this PR runs