### PR TITLE
fix(ci): add gate job so required 'test' check resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check code formatting
         run: npm run format:check
 
-  test:
+  test-browser:
     name: Test (${{ matrix.browser }})
     runs-on: ubuntu-latest
     needs: lint
@@ -79,3 +79,9 @@ jobs:
           name: playwright-report-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 7
+
+  test:
+    runs-on: ubuntu-latest
+    needs: test-browser
+    steps:
+      - run: echo "All tests passed"


### PR DESCRIPTION
## Summary

- The branch protection rule on `main` requires a status check named `"test"`
- The matrix job produces checks named `"Test (chromium)"` and `"Test (firefox)"` — never `"test"` — so the required check is permanently pending
- Renames the matrix job to `test-browser` and adds a gate job (`test`) that fans in both, reporting under the expected name

## Test plan

- [ ] Verify the `test` check appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)