### PR TITLE
feat: apply design system to live site

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,0 +1,258 @@
+/* ============================================================
+   Synkope — Component styles
+   Depends on tokens.css. Import AFTER tokens.css.
+   Classes prefixed .s-* are the new, doc'd system; existing
+   class names in style.css continue to work via token aliases.
+   ============================================================ */
+
+/* ---------- Buttons ---------- */
+.s-btn {
+  display: inline-block;
+  padding: 12px 30px;
+  border: none;
+  border-radius: var(--s-radius);
+  text-decoration: none;
+  font-family: var(--s-font-body);
+  font-weight: 600;
+  font-size: var(--s-fs-body);
+  cursor: pointer;
+  transition: var(--s-transition);
+  text-align: center;
+}
+.s-btn:focus-visible {
+  outline: 2px solid var(--s-primary);
+  outline-offset: 2px;
+}
+.s-btn--primary {
+  background: var(--s-primary);
+  color: #fff;
+}
+.s-btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--s-shadow-btn);
+}
+.s-btn--secondary {
+  background: transparent;
+  color: var(--s-primary);
+  border: 2px solid var(--s-primary);
+  padding: 10px 28px;
+}
+.s-btn--secondary:hover {
+  background: var(--s-primary);
+  color: #fff;
+  transform: translateY(-2px);
+}
+.s-btn--link {
+  background: none;
+  color: var(--s-secondary);
+  padding: 6px 0;
+  border-radius: 0;
+  border-bottom: 1px solid transparent;
+  font-weight: 400;
+  font-size: var(--s-fs-small);
+}
+.s-btn--link:hover {
+  color: var(--s-primary-light);
+  border-bottom-color: var(--s-primary-light);
+}
+
+/* ---------- Cards ---------- */
+.s-card {
+  background: var(--s-gradient-card-surface);
+  padding: var(--s-space-xl);
+  border-radius: var(--s-radius-xl);
+  box-shadow: var(--s-shadow-soft);
+  border: 1px solid rgba(255, 165, 80, 0.15);
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+  transition: var(--s-transition);
+}
+.s-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--s-gradient-card-rule);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.s-card:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--s-shadow-hover);
+}
+.s-card:hover::before {
+  opacity: 0.9;
+}
+.s-card h3 {
+  color: var(--s-primary-light);
+  font-family: var(--s-font-heading);
+  font-weight: 600;
+  font-size: var(--s-fs-h3);
+  margin-bottom: var(--s-space-md);
+}
+.s-card p {
+  color: var(--s-text);
+  line-height: var(--s-lh-body);
+  margin-bottom: var(--s-space-lg);
+}
+
+/* Accent (orange fill) card */
+.s-card--accent {
+  background: var(--s-gradient-orange);
+  color: #fff;
+  border: none;
+}
+.s-card--accent h3 {
+  color: #fff;
+}
+.s-card--accent p {
+  color: rgba(255, 255, 255, 0.9);
+}
+.s-card--accent .s-btn--primary {
+  background: #fff;
+  color: var(--s-primary);
+}
+
+/* ---------- Team member ---------- */
+.s-team {
+  background: var(--s-gradient-card-team);
+  border-radius: var(--s-radius-lg);
+  padding: 2rem;
+  box-shadow:
+    0 6px 25px rgba(29, 95, 129, 0.12),
+    0 2px 10px rgba(255, 165, 80, 0.08);
+  text-align: center;
+  border: 1px solid rgba(255, 165, 80, 0.12);
+  transition: var(--s-transition);
+}
+.s-team:hover {
+  transform: translateY(-5px);
+  box-shadow:
+    0 15px 45px rgba(29, 95, 129, 0.18),
+    0 5px 20px rgba(255, 165, 80, 0.12);
+}
+.s-team-photo {
+  width: 200px;
+  height: 200px;
+  margin: 0 auto var(--s-space-lg);
+  border-radius: 50%;
+  overflow: hidden;
+  border: 4px solid var(--s-primary);
+}
+.s-team-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.s-team h3 {
+  color: var(--s-primary);
+  font-family: var(--s-font-heading);
+  font-weight: 600;
+  font-size: var(--s-fs-h3);
+  margin-bottom: 0.5rem;
+}
+
+/* ---------- Forms ---------- */
+.s-form {
+  background: var(--s-gradient-card-form);
+  padding: 2rem;
+  border-radius: var(--s-radius-xl);
+  box-shadow:
+    0 6px 25px rgba(29, 95, 129, 0.08),
+    0 2px 10px rgba(255, 165, 80, 0.08);
+  border: 1px solid rgba(255, 165, 80, 0.15);
+}
+.s-form-group {
+  margin-bottom: 1.5rem;
+}
+.s-form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--s-text);
+  font-size: var(--s-fs-small);
+}
+.s-form-group input,
+.s-form-group textarea {
+  width: 100%;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: var(--s-radius);
+  font-family: inherit;
+  font-size: var(--s-fs-body);
+  transition: border-color 0.3s ease;
+}
+.s-form-group input:focus,
+.s-form-group textarea:focus {
+  outline: none;
+  border-color: var(--s-primary-light);
+}
+.s-form-group .error {
+  border-color: var(--s-error);
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+}
+
+/* ---------- Utility: container ---------- */
+.s-container {
+  max-width: var(--s-container);
+  margin: 0 auto;
+  padding: 0 var(--s-gutter);
+}
+
+/* ---------- Utility: section rhythm ---------- */
+.s-section {
+  padding: var(--s-space-3xl) 0;
+}
+@media (max-width: 768px) {
+  .s-section {
+    padding: 60px 0;
+  }
+}
+
+/* ---------- Bullet list ---------- */
+.s-list {
+  list-style: none;
+  background: #f8fafc;
+  border-radius: var(--s-radius-lg);
+  padding: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+.s-list li {
+  position: relative;
+  padding: 1rem 0 1rem 2rem;
+  color: var(--s-text);
+  font-weight: 500;
+  line-height: var(--s-lh-body);
+  border-bottom: 1px solid #e2e8f0;
+}
+.s-list li:last-child {
+  border-bottom: none;
+}
+.s-list li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 1rem;
+  color: var(--s-primary-light);
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+  .s-card:hover,
+  .s-team:hover,
+  .s-btn--primary:hover,
+  .s-btn--secondary:hover {
+    transform: none;
+  }
+}

--- a/css/components.css
+++ b/css/components.css
@@ -146,12 +146,12 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
 }
 .s-team h3 {
   color: var(--s-primary);
   font-family: var(--s-font-heading);
   font-weight: 600;
-  font-size: var(--s-fs-h3);
   margin-bottom: 0.5rem;
 }
 
@@ -190,7 +190,8 @@
   outline: none;
   border-color: var(--s-primary-light);
 }
-.s-form-group .error {
+.s-form-group input.error,
+.s-form-group textarea.error {
   border-color: var(--s-error);
   box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -543,12 +543,6 @@ section {
   min-height: 120px;
 }
 
-.s-form-group input.error,
-.s-form-group textarea.error {
-  border-color: var(--s-error);
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
-}
-
 /* Form Messages */
 .form-message {
   padding: 1rem;
@@ -1116,25 +1110,6 @@ section {
   color: var(--text-color);
   font-size: 0.9rem;
   margin-bottom: 0;
-}
-
-.service-contact-card {
-  background: linear-gradient(135deg, #eb8822 0%, #d67316 100%);
-  color: white;
-  padding: 2rem;
-  border-radius: 15px;
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.service-contact-card h3 {
-  color: white;
-  margin-bottom: 1rem;
-}
-
-.service-contact-card p {
-  color: rgba(255, 255, 255, 0.9);
-  margin-bottom: 1.5rem;
 }
 
 .service-related {

--- a/css/style.css
+++ b/css/style.css
@@ -1,19 +1,4 @@
-/* CSS Custom Properties */
-:root {
-  --primary-color: #eb8822;
-  --secondary-color: #1d5f81;
-  --text-color: #1d5f81;
-  --background-color: #ffffff;
-  --container-width: 1200px;
-  --border-radius: 8px;
-  --transition: all 0.3s ease;
-  --font-family-heading: "Inter", sans-serif;
-  --font-family-body: "Open Sans", sans-serif;
-  --primary-color-light: #ff9f50;
-  --primary-color-lighter: #ffb366;
-  --border-color-light: #f2f3f5;
-  --bg-hover: #f5f7fa;
-}
+/* Tokens are defined in tokens.css — loaded before this file */
 
 /* ================================
    SKIP LINK
@@ -94,46 +79,7 @@ p {
   color: var(--text-color);
 }
 
-/* Buttons */
-.btn {
-  display: inline-block;
-  padding: 12px 30px;
-  border: none;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  text-align: center;
-}
-
-.btn:focus {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
-}
-
-.btn-primary {
-  background: var(--primary-color);
-  color: white;
-}
-
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(235, 136, 34, 0.3);
-}
-
-.btn-secondary {
-  background: transparent;
-  color: var(--primary-color);
-  border: 2px solid var(--primary-color);
-}
-
-.btn-secondary:hover {
-  background: var(--primary-color);
-  color: white;
-  transform: translateY(-2px);
-}
+/* Buttons — .s-btn / .s-btn--primary / .s-btn--secondary defined in components.css */
 
 /* Navigation */
 .navbar {
@@ -487,41 +433,7 @@ section {
   gap: 2rem;
 }
 
-.service-card {
-  background: linear-gradient(145deg, #ffffff 0%, #fefcfb 100%);
-  padding: 2.5rem;
-  border-radius: 15px;
-  box-shadow:
-    0 8px 25px rgba(29, 95, 129, 0.08),
-    0 3px 10px rgba(255, 165, 80, 0.08);
-  text-align: center;
-  transition: all 0.3s ease;
-  border: 1px solid rgba(255, 165, 80, 0.15);
-  position: relative;
-  overflow: hidden;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.service-card::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(
-    90deg,
-    var(--primary-color-light) 0%,
-    var(--primary-color-lighter) 50%,
-    var(--primary-color-light) 100%
-  );
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
+/* Service cards — .s-card defined in components.css; flex layout overrides below */
 .service-card-link {
   text-decoration: none;
   color: inherit;
@@ -529,51 +441,25 @@ section {
   transition: all 0.3s ease;
 }
 
-.service-card-link:hover .service-card,
-.service-card:hover {
-  transform: translateY(-5px);
-  box-shadow:
-    0 12px 35px rgba(29, 95, 129, 0.15),
-    0 4px 15px rgba(255, 165, 80, 0.1);
+.services-grid .s-card {
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
-.service-card:hover::before {
-  opacity: 0.6;
-}
-
-.service-card h3 {
-  color: var(--primary-color-light);
-  margin-bottom: 1rem;
-  font-size: 1.5rem;
-}
-
-.service-card p {
-  color: var(--text-color);
-  line-height: 1.6;
-  margin-bottom: 1.5rem;
+.services-grid .s-card p {
   flex-grow: 1;
 }
 
-.service-link {
-  display: inline-block;
-  color: var(--secondary-color);
-  text-decoration: none;
-  font-weight: 400;
-  padding: 0.3rem 0;
-  border: none;
-  border-bottom: 1px solid transparent;
-  border-radius: 0;
-  transition: all 0.3s ease;
-  margin-top: auto;
-  font-size: 0.9rem;
+.service-card-link:hover .s-card {
+  transform: translateY(-5px);
+  box-shadow: var(--s-shadow-hover);
+  cursor: pointer;
 }
 
-.service-link:hover {
-  color: var(--primary-color-light);
-  border-bottom-color: var(--primary-color-light);
-  background: transparent;
-  transform: none;
+.services-grid .s-btn--link {
+  margin-top: auto;
 }
 
 /* Portfolio Section */
@@ -646,61 +532,20 @@ section {
   align-items: center;
 }
 
-.contact-form {
-  background: linear-gradient(145deg, #faf9f8 0%, #ffffff 100%);
-  padding: 2rem;
-  border-radius: 15px;
+/* Contact form — .s-form / .s-form-group defined in components.css */
+.s-form {
   max-width: 600px;
   width: 100%;
-  box-shadow:
-    0 6px 25px rgba(29, 95, 129, 0.08),
-    0 2px 10px rgba(255, 165, 80, 0.08);
-  border: 1px solid rgba(255, 165, 80, 0.15);
 }
 
-.form-group {
-  margin-bottom: 1.5rem;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--text-color);
-  font-size: 0.9rem;
-}
-
-.form-group input,
-.form-group textarea {
-  width: 100%;
-  padding: 1rem;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-family: inherit;
-  font-size: 1rem;
-  transition: border-color 0.3s ease;
-}
-
-.form-group input:focus,
-.form-group textarea:focus {
-  outline: none;
-  border-color: var(--primary-color-light);
-}
-
-.form-group textarea {
+.s-form-group textarea {
   resize: vertical;
   min-height: 120px;
 }
 
-.form-group input.error,
-.form-group textarea.error {
-  border-color: #dc3545;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
-}
-
-.form-group input.error:focus,
-.form-group textarea.error:focus {
-  border-color: #dc3545;
+.s-form-group input.error,
+.s-form-group textarea.error {
+  border-color: var(--s-error);
   box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
 }
 
@@ -869,42 +714,7 @@ section {
   }
 }
 
-.team-member {
-  background: linear-gradient(145deg, #ffffff 0%, #fefcf8 100%);
-  border-radius: 12px;
-  padding: 2rem;
-  box-shadow:
-    0 6px 25px rgba(29, 95, 129, 0.12),
-    0 2px 10px rgba(255, 165, 80, 0.08);
-  transition:
-    transform 0.3s ease,
-    box-shadow 0.3s ease;
-  text-align: center;
-  border: 1px solid rgba(255, 165, 80, 0.12);
-}
-
-.team-member:hover {
-  transform: translateY(-5px);
-  box-shadow:
-    0 15px 45px rgba(29, 95, 129, 0.18),
-    0 5px 20px rgba(255, 165, 80, 0.12);
-}
-
-.team-photo {
-  width: 200px;
-  height: 200px;
-  margin: 0 auto 1.5rem;
-  border-radius: 50%;
-  overflow: hidden;
-  border: 4px solid var(--primary-color);
-}
-
-.team-photo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-}
+/* Team cards — .s-team / .s-team-photo defined in components.css */
 
 .team-info h3 {
   color: var(--primary-color);
@@ -950,12 +760,12 @@ section {
     margin-top: 2rem;
   }
 
-  .team-member {
+  .s-team {
     padding: 1.5rem;
     margin: 0 1rem;
   }
 
-  .team-photo {
+  .s-team-photo {
     width: 150px;
     height: 150px;
   }
@@ -1065,7 +875,7 @@ section {
     padding: 0 1rem;
   }
 
-  .contact-form {
+  .s-form {
     max-width: none;
   }
 
@@ -1074,7 +884,7 @@ section {
     gap: 2rem;
   }
 
-  .service-card {
+  .services-grid .s-card {
     text-align: center;
     padding: 2rem 1.5rem;
   }
@@ -1122,17 +932,17 @@ section {
     font-size: 1.1rem;
   }
 
-  .service-card,
-  .contact-form {
+  .services-grid .s-card,
+  .s-form {
     padding: 1.5rem;
   }
 
-  .team-member {
+  .s-team {
     padding: 1.2rem;
     margin: 0 0.5rem;
   }
 
-  .team-photo {
+  .s-team-photo {
     width: 120px;
     height: 120px;
   }
@@ -1148,7 +958,7 @@ section {
     font-size: 0.85rem;
   }
 
-  .btn {
+  .s-btn {
     padding: 12px 24px;
     font-size: 0.9rem;
   }
@@ -1173,13 +983,13 @@ section {
 
 /* Touch improvements */
 @media (hover: none) and (pointer: coarse) {
-  .btn:hover,
+  .s-btn:hover,
   .nav-link:hover,
-  .team-member:hover {
+  .s-team:hover {
     transform: none;
   }
 
-  .btn:active {
+  .s-btn:active {
     transform: scale(0.98);
   }
 
@@ -1275,39 +1085,7 @@ section {
   border-bottom: 2px solid #e5e7eb;
 }
 
-.service-list {
-  list-style: none;
-  padding: 0;
-  margin: 3rem 0;
-  background: #f8fafc;
-  border-radius: 12px;
-  padding: 2rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-
-.service-list li {
-  position: relative;
-  padding: 1rem 0 1rem 2rem;
-  color: var(--text-color);
-  font-weight: 500;
-  line-height: 1.6;
-  border-bottom: 1px solid #e2e8f0;
-  font-size: 1.05rem;
-}
-
-.service-list li:last-child {
-  border-bottom: none;
-}
-
-.service-list li::before {
-  content: "▸";
-  position: absolute;
-  left: 0;
-  top: 1rem;
-  color: var(--primary-color-light);
-  font-weight: bold;
-  font-size: 1.2rem;
-}
+/* Service list — .s-list defined in components.css */
 
 .competence-grid {
   display: grid;

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,110 @@
+/* ============================================================
+   Synkope — Design Tokens
+   Single source of truth for color, type, spacing, radius, shadow.
+   Import this FIRST in any stylesheet.
+   ============================================================ */
+
+:root {
+  /* ---------- Brand colors ---------- */
+  --s-primary: #eb8822;
+  --s-primary-light: #ff9f50;
+  --s-primary-lighter: #ffb366;
+  --s-primary-dark: #d67316;
+
+  --s-secondary: #1d5f81;
+  --s-text: #1d5f81;
+  --s-bg: #ffffff;
+
+  /* ---------- Warm neutral scale ---------- */
+  --s-cream-1: #faf8f5;
+  --s-cream-2: #f8f2e8;
+  --s-cream-3: #f4e9da;
+  --s-cream-4: #e2cfc3;
+  --s-warm-1: #fbf9f8;
+  --s-warm-2: #fcf8f0;
+  --s-warm-3: #fcf5e8;
+
+  /* ---------- Utility colors ---------- */
+  --s-border-light: #f2f3f5;
+  --s-bg-hover: #f5f7fa;
+  --s-footer: #2c3e50;
+  --s-footer-border: #34495e;
+  --s-footer-muted: #bdc3c7;
+  --s-error: #dc3545;
+
+  /* ---------- Signature gradients ---------- */
+  --s-gradient-hero: linear-gradient(135deg, #faf8f5 0%, #f8f2e8 30%, #f4e9da 70%, #e2cfc3 100%);
+  --s-gradient-section: linear-gradient(135deg, #fcf8f0 0%, #fcf5e8 50%, #ffffff 100%);
+  --s-gradient-about: linear-gradient(135deg, #fbf9f8 0%, #ffffff 50%, #fcf7f2 100%);
+  --s-gradient-brand: linear-gradient(135deg, var(--s-primary) 0%, var(--s-secondary) 100%);
+  --s-gradient-orange: linear-gradient(135deg, var(--s-primary) 0%, var(--s-primary-dark) 100%);
+  --s-gradient-card-surface: linear-gradient(145deg, #ffffff 0%, #fefcfb 100%);
+  --s-gradient-card-team: linear-gradient(145deg, #ffffff 0%, #fefcf8 100%);
+  --s-gradient-card-form: linear-gradient(145deg, #faf9f8 0%, #ffffff 100%);
+  --s-gradient-card-rule: linear-gradient(
+    90deg,
+    var(--s-primary-light) 0%,
+    var(--s-primary-lighter) 50%,
+    var(--s-primary-light) 100%
+  );
+
+  /* ---------- Typography ---------- */
+  --s-font-heading: "Inter", sans-serif;
+  --s-font-body: "Open Sans", sans-serif;
+
+  --s-fs-h1: 3.5rem; /* 56px */
+  --s-fs-h2: 2.5rem; /* 40px */
+  --s-fs-h3: 1.8rem; /* ~29px */
+  --s-fs-lede: 1.25rem; /* 20px */
+  --s-fs-body: 1rem; /* 16px */
+  --s-fs-small: 0.9rem; /* ~14.4px */
+
+  --s-lh-tight: 1.2;
+  --s-lh-body: 1.6;
+
+  /* ---------- Spacing scale (8px base) ---------- */
+  --s-space-xs: 4px;
+  --s-space-sm: 8px;
+  --s-space-md: 16px;
+  --s-space-lg: 24px;
+  --s-space-xl: 40px;
+  --s-space-2xl: 64px;
+  --s-space-3xl: 80px; /* section padding */
+  --s-space-4xl: 120px; /* hero padding */
+
+  /* ---------- Radius scale ---------- */
+  --s-radius-sm: 6px;
+  --s-radius: 8px;
+  --s-radius-lg: 12px;
+  --s-radius-xl: 15px;
+  --s-radius-pill: 999px;
+
+  /* ---------- Shadow scale ---------- */
+  --s-shadow-soft: 0 8px 25px rgba(29, 95, 129, 0.08), 0 3px 10px rgba(255, 165, 80, 0.08);
+  --s-shadow-hover: 0 12px 35px rgba(29, 95, 129, 0.15), 0 4px 15px rgba(255, 165, 80, 0.1);
+  --s-shadow-nav: 0 2px 20px rgba(0, 0, 0, 0.1);
+  --s-shadow-btn: 0 10px 30px rgba(235, 136, 34, 0.3);
+
+  /* ---------- Layout ---------- */
+  --s-container: 1200px;
+  --s-gutter: 20px;
+
+  /* ---------- Motion ---------- */
+  --s-transition: all 0.3s ease;
+  --s-transition-fast: all 0.15s ease;
+
+  /* ---------- Legacy aliases (keep style.css working) ---------- */
+  --primary-color: var(--s-primary);
+  --primary-color-light: var(--s-primary-light);
+  --primary-color-lighter: var(--s-primary-lighter);
+  --secondary-color: var(--s-secondary);
+  --text-color: var(--s-text);
+  --background-color: var(--s-bg);
+  --container-width: var(--s-container);
+  --border-radius: var(--s-radius);
+  --transition: var(--s-transition);
+  --font-family-heading: var(--s-font-heading);
+  --font-family-body: var(--s-font-body);
+  --border-color-light: var(--s-border-light);
+  --bg-hover: var(--s-bg-hover);
+}

--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="css/tokens.css" />
+    <link rel="stylesheet" href="css/components.css" />
     <link rel="stylesheet" href="css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Open+Sans:wght@300;400;600&display=swap"
@@ -129,7 +131,7 @@
             både privat og offentlig sektor med å løse komplekse utfordringer innen teknologi og
             prosjektledelse.
           </p>
-          <a href="#kontakt" class="btn btn-primary">Ta kontakt</a>
+          <a href="#kontakt" class="s-btn s-btn--primary">Ta kontakt</a>
         </div>
         <div class="hero-image">
           <!-- Placeholder for hero image -->
@@ -176,42 +178,42 @@
         </div>
         <div class="services-grid">
           <a href="tjenester/it-infrastruktur.html" class="service-card-link">
-            <div class="service-card">
+            <div class="s-card">
               <h3>IT-infrastruktur og cloud</h3>
               <p>
                 GitOps og infrastruktur som kode muliggjør rask og sikker utvikling i skymiljøer.
               </p>
-              <span class="service-link">Les mer →</span>
+              <span class="s-btn s-btn--link">Les mer →</span>
             </div>
           </a>
           <a href="tjenester/prosjektstyring.html" class="service-card-link">
-            <div class="service-card">
+            <div class="s-card">
               <h3>Prosjektstyring</h3>
               <p>
                 Våre prosjektledere skaper engasjement og bidrar til effektivt samarbeid og
                 kommunikasjon i prosjekter.
               </p>
-              <span class="service-link">Les mer →</span>
+              <span class="s-btn s-btn--link">Les mer →</span>
             </div>
           </a>
           <a href="tjenester/informasjonssikkerhet.html" class="service-card-link">
-            <div class="service-card">
+            <div class="s-card">
               <h3>Informasjonssikkerhet</h3>
               <p>
                 Integrering av sikkerhet i IT-infrastruktur og systemutvikling. Vi tilbyr
                 risikovurderinger og sikkerhetstiltak for kritiske systemer.
               </p>
-              <span class="service-link">Les mer →</span>
+              <span class="s-btn s-btn--link">Les mer →</span>
             </div>
           </a>
           <a href="tjenester/emc.html" class="service-card-link">
-            <div class="service-card">
+            <div class="s-card">
               <h3>Elektromagnetisk kompatibilitet (EMC)</h3>
               <p>
                 Med spisskompetanse innenfor EMC hjelper vi leverandører med å forstå, teste og
                 oppfylle militære krav til utstyr, systemer og fartøy.
               </p>
-              <span class="service-link">Les mer →</span>
+              <span class="s-btn s-btn--link">Les mer →</span>
             </div>
           </a>
         </div>
@@ -225,8 +227,8 @@
           <h2 id="team-heading">Team</h2>
         </div>
         <div class="team-grid">
-          <div class="team-member">
-            <div class="team-photo">
+          <div class="s-team">
+            <div class="s-team-photo">
               <img src="images/andreas-strom.jpg" alt="Andreas Strøm" loading="lazy" />
             </div>
             <div class="team-info">
@@ -250,8 +252,8 @@
             </div>
           </div>
 
-          <div class="team-member">
-            <div class="team-photo">
+          <div class="s-team">
+            <div class="s-team-photo">
               <img src="images/irene-driveklepp.jpg" alt="Irene Driveklepp" loading="lazy" />
             </div>
             <div class="team-info">
@@ -274,8 +276,8 @@
             </div>
           </div>
 
-          <div class="team-member">
-            <div class="team-photo">
+          <div class="s-team">
+            <div class="s-team-photo">
               <img src="images/erik-straede.jpg" alt="Erik Stræde" loading="lazy" />
             </div>
             <div class="team-info">
@@ -298,8 +300,8 @@
             </div>
           </div>
 
-          <div class="team-member">
-            <div class="team-photo">
+          <div class="s-team">
+            <div class="s-team-photo">
               <img src="images/torkell-bogstad.jpg" alt="Torkell Bogstad" loading="lazy" />
             </div>
             <div class="team-info">
@@ -364,13 +366,13 @@
           <h2 id="contact-heading">Kontakt oss</h2>
         </div>
         <div class="contact-content">
-          <div class="contact-form">
+          <div class="s-form">
             <!-- TODO: Replace YOUR_FORM_ID with the real Formspree form ID before going live -->
             <form
               id="kontaktskjema"
               data-formspree-id="YOUR_FORM_ID"
               aria-labelledby="contact-heading">
-              <div class="form-group">
+              <div class="s-form-group">
                 <label for="navn">Navn *</label>
                 <input
                   type="text"
@@ -380,7 +382,7 @@
                   required
                   aria-required="true" />
               </div>
-              <div class="form-group">
+              <div class="s-form-group">
                 <label for="epost">E-post *</label>
                 <input
                   type="email"
@@ -390,7 +392,7 @@
                   required
                   aria-required="true" />
               </div>
-              <div class="form-group">
+              <div class="s-form-group">
                 <label for="emne">Emne *</label>
                 <input
                   type="text"
@@ -400,7 +402,7 @@
                   required
                   aria-required="true" />
               </div>
-              <div class="form-group">
+              <div class="s-form-group">
                 <label for="melding">Melding *</label>
                 <textarea
                   id="melding"
@@ -410,7 +412,7 @@
                   required
                   aria-required="true"></textarea>
               </div>
-              <button type="submit" class="btn btn-primary">Send melding</button>
+              <button type="submit" class="s-btn s-btn--primary">Send melding</button>
               <p class="form-fallback">
                 Du kan også nå oss direkte på <a href="mailto:post@synkope.io">post@synkope.io</a>
               </p>

--- a/js/service-content-loader.js
+++ b/js/service-content-loader.js
@@ -113,7 +113,7 @@ class ServiceContentLoader {
     // Add key competencies list
     if (content.key_competencies && content.key_competencies.length > 0) {
       const ul = document.createElement("ul");
-      ul.className = "service-list";
+      ul.className = "s-list";
 
       content.key_competencies.forEach((competency) => {
         const li = document.createElement("li");
@@ -151,7 +151,7 @@ class ServiceContentLoader {
         // Add section services list
         if (section.services && section.services.length > 0) {
           const ul = document.createElement("ul");
-          ul.className = "service-list";
+          ul.className = "s-list";
 
           section.services.forEach((service) => {
             const li = document.createElement("li");
@@ -180,7 +180,7 @@ class ServiceContentLoader {
     listFields.forEach((field) => {
       if (content[field] && Array.isArray(content[field])) {
         const ul = document.createElement("ul");
-        ul.className = "service-list";
+        ul.className = "s-list";
 
         content[field].forEach((item) => {
           const li = document.createElement("li");

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -85,7 +85,7 @@ test.describe("Synkope Website - Main Functionality", () => {
     await page.click('a[href="#team"]');
 
     // Check team member cards are visible
-    const teamMembers = page.locator(".team-member");
+    const teamMembers = page.locator(".s-team");
     await expect(teamMembers).toHaveCount(4);
 
     // Check specific team members
@@ -95,7 +95,7 @@ test.describe("Synkope Website - Main Functionality", () => {
     await expect(page.locator("text=Torkell Bogstad")).toBeVisible();
 
     // Check team member images are loaded
-    const teamImages = page.locator(".team-photo img");
+    const teamImages = page.locator(".s-team-photo img");
     await expect(teamImages).toHaveCount(4);
 
     // Check contact links are present
@@ -107,7 +107,7 @@ test.describe("Synkope Website - Main Functionality", () => {
     await page.click('a[href="#tjenester"]');
 
     // Check service cards are visible
-    const serviceCards = page.locator(".service-card");
+    const serviceCards = page.locator(".s-card");
     await expect(serviceCards).toHaveCount(4);
 
     // Check service card content
@@ -180,7 +180,7 @@ test.describe("Synkope Website - Main Functionality", () => {
     await expect(logo).toBeVisible();
 
     // Check that team images are loaded
-    const teamImages = page.locator(".team-photo img");
+    const teamImages = page.locator(".s-team-photo img");
     const imageCount = await teamImages.count();
 
     for (let i = 0; i < imageCount; i++) {

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -112,10 +112,10 @@ test.describe("Synkope Website - Main Functionality", () => {
 
     // Check service card content
     const servicesGrid = page.locator(".services-grid");
-    await expect(servicesGrid.locator("text=IT-infrastruktur")).toBeVisible();
-    await expect(servicesGrid.locator("text=Prosjektstyring")).toBeVisible();
-    await expect(servicesGrid.locator("text=Informasjonssikkerhet")).toBeVisible();
-    await expect(servicesGrid.locator("text=Elektromagnetisk kompatibilitet")).toBeVisible();
+    await expect(servicesGrid.locator("h3", { hasText: "IT-infrastruktur" })).toBeVisible();
+    await expect(servicesGrid.locator("h3", { hasText: "Prosjektstyring" })).toBeVisible();
+    await expect(servicesGrid.locator("h3", { hasText: "Informasjonssikkerhet" })).toBeVisible();
+    await expect(servicesGrid.locator("h3", { hasText: "Elektromagnetisk kompatibilitet" })).toBeVisible();
 
     // Test service card links
     const iktLink = servicesGrid.locator('a[href="tjenester/it-infrastruktur.html"]');

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -55,7 +55,7 @@ test.describe("Smoke Tests - Critical Functionality", () => {
     await page.waitForSelector("#team", { state: "visible" });
 
     // Wait for team members to be present in DOM
-    const teamMembers = page.locator(".team-member");
+    const teamMembers = page.locator(".s-team");
     await teamMembers.first().waitFor({ state: "visible", timeout: 15000 });
 
     // Check we have the expected number of team members
@@ -63,7 +63,7 @@ test.describe("Smoke Tests - Critical Functionality", () => {
 
     // Wait for content to load from JSON by checking all team member descriptions
     // Some browsers (especially webkit/Safari) can be slower to load JSON
-    const firstMemberDesc = page.locator(".team-member").first().locator(".team-info p");
+    const firstMemberDesc = page.locator(".s-team").first().locator(".team-info p");
 
     // Wait for the JSON content to actually load - retry with polling
     await expect(async () => {

--- a/tjenester/emc.html
+++ b/tjenester/emc.html
@@ -56,6 +56,8 @@
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="../css/tokens.css" />
+    <link rel="stylesheet" href="../css/components.css" />
     <link rel="stylesheet" href="../css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Open+Sans:wght@300;400;600&display=swap"

--- a/tjenester/informasjonssikkerhet.html
+++ b/tjenester/informasjonssikkerhet.html
@@ -58,6 +58,8 @@
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="../css/tokens.css" />
+    <link rel="stylesheet" href="../css/components.css" />
     <link rel="stylesheet" href="../css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Open+Sans:wght@300;400;600&display=swap"

--- a/tjenester/it-infrastruktur.html
+++ b/tjenester/it-infrastruktur.html
@@ -58,6 +58,8 @@
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="../css/tokens.css" />
+    <link rel="stylesheet" href="../css/components.css" />
     <link rel="stylesheet" href="../css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Open+Sans:wght@300;400;600&display=swap"

--- a/tjenester/prosjektstyring.html
+++ b/tjenester/prosjektstyring.html
@@ -58,6 +58,8 @@
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="../css/tokens.css" />
+    <link rel="stylesheet" href="../css/components.css" />
     <link rel="stylesheet" href="../css/style.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Open+Sans:wght@300;400;600&display=swap"


### PR DESCRIPTION
## Summary

- Wires `tokens.css → components.css → style.css` on all 5 HTML pages
- Migrates HTML classes to `.s-*` equivalents (`.btn` → `.s-btn`, `.service-card` → `.s-card`, `.team-member` → `.s-team`, etc.)
- Removes ~282 lines from `style.css` now owned by the design system
- Adds `css/tokens.css` and `css/components.css` so the HTML stylesheet links resolve correctly

## Test plan

- [ ] Homepage loads with correct fonts (Inter/Open Sans) and brand orange color
- [ ] Service cards, team section, and contact form render correctly
- [ ] All four service sub-pages load without visual regressions
- [ ] Mobile hamburger menu and responsive layout work
- [ ] CI passes (lint + Playwright tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)