### PR TITLE
fix: correct hero spacing and scroll-margin-top for fixed navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -142,10 +142,14 @@ p {
   }
 }
 
-/* Larger logo for big screens */
+/* Larger logo for big screens — navbar is ~138px tall (90px logo + 2×24px padding) */
 @media (min-width: 1200px) {
   .logo-image {
     height: 90px;
+  }
+
+  .hero {
+    padding-top: 150px;
   }
 }
 
@@ -847,7 +851,7 @@ section {
   }
 
   .hero {
-    padding: 105px 0 80px;
+    padding: 120px 0 80px;
   }
 
   .hero-container {
@@ -919,7 +923,7 @@ section {
   }
 
   .hero {
-    padding: 85px 0 60px;
+    padding: 120px 0 60px;
   }
 
   .hero-subtitle {
@@ -993,9 +997,21 @@ section {
   }
 }
 
-/* Smooth scrolling offset for fixed navbar */
+/* Smooth scrolling offset for fixed navbar (~102px desktop, ~122px wide, ~108px mobile) */
 section {
-  scroll-margin-top: 65px;
+  scroll-margin-top: 110px;
+}
+
+@media (min-width: 1200px) {
+  section {
+    scroll-margin-top: 130px;
+  }
+}
+
+@media (max-width: 768px) {
+  section {
+    scroll-margin-top: 115px;
+  }
 }
 
 /* Loading animation for better UX */

--- a/css/style.css
+++ b/css/style.css
@@ -142,7 +142,7 @@ p {
   }
 }
 
-/* Larger logo for big screens — navbar is ~138px tall (90px logo + 2×24px padding) */
+/* Larger logo for big screens — navbar is ~122px tall (90px logo + 2×16px padding) */
 @media (min-width: 1200px) {
   .logo-image {
     height: 90px;
@@ -850,10 +850,6 @@ section {
     font-size: 2rem;
   }
 
-  .hero {
-    padding: 120px 0 80px;
-  }
-
   .hero-container {
     grid-template-columns: 1fr;
     text-align: center;
@@ -997,7 +993,9 @@ section {
   }
 }
 
-/* Smooth scrolling offset for fixed navbar (~102px desktop, ~122px wide, ~108px mobile) */
+/* Smooth scrolling offset for fixed navbar.
+   Base (110px) covers the 768–1199px desktop range (~102px navbar + buffer).
+   Overrides handle narrower/wider ranges where the navbar is taller. */
 section {
   scroll-margin-top: 110px;
 }
@@ -1172,7 +1170,7 @@ section {
 /* Mobile styles for service pages */
 @media (max-width: 768px) {
   .service-hero {
-    padding: 105px 0 20px;
+    padding: 120px 0 20px;
   }
 
   .service-hero h1 {


### PR DESCRIPTION
## Summary

The fixed navbar height differs by breakpoint but the hero `padding-top` and `scroll-margin-top` values didn't account for this:

| Breakpoint | Navbar height | Old hero padding-top | Old scroll-margin-top |
|---|---|---|---|
| ≤480px | ~108px | 85px ❌ | 65px ❌ |
| ≤768px | ~108px | 105px ❌ | 65px ❌ |
| 768–1199px | ~102px | 120px ✓ | 65px ❌ |
| ≥1200px | ~122px | 120px ❌ | 65px ❌ |

**Result**: hero h1 was hidden 2–23px behind the navbar on most breakpoints; section headings jumped behind the navbar on anchor navigation.

**Fix**: hero `padding-top` raised to 120px / 120px / 150px; `scroll-margin-top` updated to 115px / 110px / 130px per breakpoint.

## Test plan

- [ ] Homepage h1 "Erfarne rådgivere" has visible gap below navbar at all viewport widths
- [ ] Clicking nav links (#om, #team, #tjenester, #kontakt) shows section headings fully below the navbar
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)