### PR TITLE
feat: implement hamburger mobile navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,7 +109,7 @@ p {
 @media (max-width: 768px) {
   .nav-container {
     padding: 0 20px;
-    justify-content: center;
+    justify-content: space-between;
   }
 
   .navbar {
@@ -789,6 +789,22 @@ section {
 
   .nav-menu {
     display: none;
+    flex-direction: column;
+    gap: 0;
+    align-items: stretch;
+    position: fixed;
+    top: 108px;
+    left: 0;
+    right: 0;
+    background: var(--s-bg);
+    padding: 0.5rem 1.5rem 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    z-index: 999;
+    border-top: 1px solid var(--s-border-light);
+  }
+
+  .nav-menu.active {
+    display: flex;
   }
 
   .nav-dropdown-menu {
@@ -799,7 +815,7 @@ section {
     visibility: hidden;
     transform: none;
     padding: 0;
-    margin-top: 1rem;
+    margin-top: 0;
     max-height: 0;
     overflow: hidden;
     transition: var(--s-transition);
@@ -813,18 +829,20 @@ section {
 
   .nav-dropdown-link {
     padding: 0.5rem 1rem;
-    margin: 0 1rem;
+    margin: 0;
     border-radius: var(--s-radius-sm);
+    color: var(--s-text);
+    font-size: 0.95rem;
   }
 
   .nav-dropdown-toggle::after {
-    display: none;
+    display: inline;
   }
 
   .nav-link {
-    padding: 1rem 0;
-    font-size: 1.1rem;
-    border-bottom: 1px solid var(--border-color-light);
+    padding: 0.9rem 0;
+    font-size: 1rem;
+    border-bottom: 1px solid var(--s-border-light);
     width: 100%;
     display: block;
   }
@@ -834,7 +852,19 @@ section {
   }
 
   .hamburger {
-    display: none;
+    display: flex;
+  }
+
+  .hamburger.active .bar:nth-child(1) {
+    transform: translateY(9px) rotate(45deg);
+  }
+
+  .hamburger.active .bar:nth-child(2) {
+    opacity: 0;
+  }
+
+  .hamburger.active .bar:nth-child(3) {
+    transform: translateY(-9px) rotate(-45deg);
   }
 
   .container {

--- a/js/script.js
+++ b/js/script.js
@@ -152,6 +152,12 @@ navLinks.forEach((link) => {
   });
 });
 
+document.addEventListener("click", (e) => {
+  if (navMenu.classList.contains("active") && !navMenu.contains(e.target) && !hamburger.contains(e.target)) {
+    toggleMobileMenu(false);
+  }
+});
+
 // --- Dropdown Menu ---
 
 const dropdown = document.querySelector(".nav-dropdown");

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -17,21 +17,23 @@ test.describe("Smoke Tests - Critical Functionality", () => {
   });
 
   test("should have working navigation", async ({ page }) => {
-    // Check navigation container exists (nav-menu might be hidden on mobile)
     const navMenu = page.locator(".nav-menu");
     const viewport = page.viewportSize();
     const isMobile = viewport && viewport.width < 768;
 
     if (isMobile) {
-      // On mobile, nav-menu is intentionally hidden (no hamburger menu in current design)
-      // Just verify the navigation structure exists in DOM
-      await expect(navMenu).toBeAttached();
+      // Hamburger opens the nav-menu
+      const hamburger = page.locator(".hamburger");
+      await expect(hamburger).toBeVisible();
+      await expect(navMenu).not.toBeVisible();
 
-      // Test that sections are accessible directly without navigation
-      await page.goto("/#om");
+      await hamburger.click();
+      await expect(navMenu).toBeVisible();
+
+      await page.click('a[href="#om"]');
       await expect(page.locator("#om")).toBeInViewport();
+      await expect(navMenu).not.toBeVisible();
     } else {
-      // On desktop, nav-menu should be visible
       await expect(navMenu).toBeVisible();
       await page.click('a[href="#om"]');
       await expect(page.locator("#om")).toBeInViewport();


### PR DESCRIPTION
## Summary
- Show `.hamburger` at ≤768px; the JS to toggle it was already there, only CSS was blocking it
- `.nav-menu.active` slides down as a fixed panel directly below the navbar (108px from top on mobile, 55px at ≤480px)
- Hamburger animates to X when open (bar 1 & 3 rotate 45°, bar 2 fades out)
- `justify-content: space-between` on mobile nav-container so logo sits left and hamburger sits right
- Outside-click handler closes the menu when tapping away from it
- Smoke test updated to verify hamburger open/close and that nav works on mobile

Closes #58

## Test plan
- [x] 15/15 Chromium tests passing locally
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)