### PR TITLE
fix: address code review findings from PRs 70-72

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1207,11 +1207,6 @@ section {
 }
 
 @media (max-width: 768px) {
-  .standards-grid,
-  .test-categories {
-    grid-template-columns: 1fr;
-  }
-
   .footer-content {
     text-align: left;
     max-width: 100%;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -34,4 +34,11 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+
+  <url>
+    <loc>https://synkope.github.io/synkope-website/personvern.html</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -67,20 +67,29 @@ test.describe("Smoke Tests - Critical Functionality", () => {
     }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
   });
 
-  test("should load service sub-pages with content", async ({ page }) => {
+  test("should load service sub-pages with content immediately (no FOUC)", async ({ page }) => {
     const servicePages = [
-      { url: "/tjenester/it-infrastruktur.html", heading: "IT-infrastruktur", text: "infrastruktur" },
+      { url: "/tjenester/it-infrastruktur.html", heading: "IT-infrastruktur", text: "Terraform" },
       { url: "/tjenester/prosjektstyring.html", heading: "Prosjektstyring", text: "prosjektleder" },
       { url: "/tjenester/informasjonssikkerhet.html", heading: "Informasjonssikkerhet", text: "ISO-27000" },
       { url: "/tjenester/emc.html", heading: "Elektromagnetisk", text: "MIL-STD" },
     ];
 
     for (const { url, heading, text } of servicePages) {
-      await page.goto(url);
+      // Wait only for DOMContentLoaded — content must be in the initial HTML parse, not injected later
+      await page.goto(url, { waitUntil: "domcontentloaded" });
 
       await expect(page.locator("h1")).toContainText(heading);
-      await expect(page.locator(".service-section")).toContainText(text);
+      const sectionText = await page.locator(".service-section").textContent();
+      expect(sectionText).toContain(text);
     }
+  });
+
+  test("should load personvern page", async ({ page }) => {
+    await page.goto("/personvern.html");
+    await expect(page).toHaveTitle(/Personvern/);
+    await expect(page.locator("h1")).toContainText("Personvern");
+    await expect(page.locator(".service-section")).toContainText("GDPR");
   });
 
   test("should load without console errors", async ({ page }) => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -89,7 +89,7 @@ test.describe("Smoke Tests - Critical Functionality", () => {
     await page.goto("/personvern.html");
     await expect(page).toHaveTitle(/Personvern/);
     await expect(page.locator("h1")).toContainText("Personvern");
-    await expect(page.locator(".service-section")).toContainText("GDPR");
+    await expect(page.locator("main")).toContainText("GDPR");
   });
 
   test("should load without console errors", async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes three issues found during post-merge code review of PRs #70–#72:

- **`css/style.css`**: Removes orphaned `.standards-grid` and `.test-categories` responsive media query selectors — their base class definitions were deleted in #72 but these responsive overrides were missed
- **`sitemap.xml`**: Adds `personvern.html` entry (added in #70 but not registered in the sitemap; the page has `robots=index,follow`)
- **`tests/smoke.spec.js`**: 
  - Uses `waitUntil: "domcontentloaded"` + synchronous `textContent()` so the test actually fails if async content loading is re-introduced (previously Playwright's auto-retry would have masked a fast loader)
  - Replaces generic keyword `"infrastruktur"` with `"Terraform"` for more distinctive matching
  - Adds smoke test for `personvern.html` (linked from all page footers but previously untested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)