### PR TITLE
fix: replace empty cert gradient boxes with SVG icons; clean up Formspree

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -483,59 +483,16 @@ section {
   gap: 2rem;
 }
 
-.portfolio-item {
-  background: var(--s-bg);
-  border-radius: var(--s-radius-xl);
-  overflow: hidden;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-  transition: var(--s-transition);
-  cursor: pointer;
+.cert-icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto var(--s-space-md);
+  color: var(--s-primary);
 }
 
-.portfolio-item:hover {
-  transform: translateY(-8px);
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.15);
-}
-
-.portfolio-image {
-  height: 200px;
-  background: #f8f9fa;
-  position: relative;
-  overflow: hidden;
-}
-
-.portfolio-image::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
+.cert-icon svg {
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-  transition: left 0.6s ease;
-}
-
-.portfolio-item:hover .portfolio-image::after {
-  left: 100%;
-}
-
-.portfolio-content {
-  padding: 1.5rem;
-  transition: var(--s-transition);
-}
-
-.portfolio-item:hover .portfolio-content {
-  transform: translateY(-5px);
-}
-
-.portfolio-content h3 {
-  color: var(--primary-color-light);
-  margin-bottom: 0.5rem;
-}
-
-.portfolio-content p {
-  color: var(--text-color);
-  margin-bottom: 1.5rem;
 }
 
 /* Contact Section */
@@ -592,16 +549,6 @@ section {
 .form-fallback a {
   color: var(--primary-color);
   text-decoration: underline;
-}
-
-/* Portfolio Image Gradients */
-.portfolio-image-gradient {
-  background: var(--s-gradient-brand);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 3rem;
-  color: white;
 }
 
 /* Footer */

--- a/index.html
+++ b/index.html
@@ -368,26 +368,60 @@
           <h2 id="kompetanse-heading">Kompetanse</h2>
         </div>
         <div class="portfolio-grid">
-          <div class="portfolio-item">
-            <div class="portfolio-image portfolio-image-gradient"></div>
-            <div class="portfolio-content">
-              <h3>Prince2® Sertifisert</h3>
-              <p>Strukturert prosjektledelsesmetodikk for kontrollert prosjektgjennomføring</p>
+          <div class="s-card">
+            <div class="cert-icon" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
             </div>
+            <h3>Prince2® Sertifisert</h3>
+            <p>Strukturert prosjektledelsesmetodikk for kontrollert prosjektgjennomføring</p>
           </div>
-          <div class="portfolio-item">
-            <div class="portfolio-image portfolio-image-gradient"></div>
-            <div class="portfolio-content">
-              <h3>SAFe Sertifisert</h3>
-              <p>Scaled Agile Framework for store og komplekse utviklingsprosjekter</p>
+          <div class="s-card">
+            <div class="cert-icon" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+              </svg>
             </div>
+            <h3>SAFe Sertifisert</h3>
+            <p>Scaled Agile Framework for store og komplekse utviklingsprosjekter</p>
           </div>
-          <div class="portfolio-item">
-            <div class="portfolio-image portfolio-image-gradient"></div>
-            <div class="portfolio-content">
-              <h3>DevOps og CI/CD</h3>
-              <p>Moderne utvikling med infrastruktur som kode og automatiserte prosesser</p>
+          <div class="s-card">
+            <div class="cert-icon" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
             </div>
+            <h3>DevOps og CI/CD</h3>
+            <p>Moderne utvikling med infrastruktur som kode og automatiserte prosesser</p>
           </div>
         </div>
       </div>
@@ -401,11 +435,7 @@
         </div>
         <div class="contact-content">
           <div class="s-form">
-            <!-- TODO: Replace YOUR_FORM_ID with the real Formspree form ID before going live -->
-            <form
-              id="kontaktskjema"
-              data-formspree-id="YOUR_FORM_ID"
-              aria-labelledby="contact-heading">
+            <form id="kontaktskjema" aria-labelledby="contact-heading">
               <div class="s-form-group">
                 <label for="navn">Navn *</label>
                 <input

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -106,8 +106,8 @@ test.describe("Synkope Website - Main Functionality", () => {
   test("should have working service cards", async ({ page }) => {
     await page.click('a[href="#tjenester"]');
 
-    // Check service cards are visible
-    const serviceCards = page.locator(".s-card");
+    // Check service cards in the services grid are visible
+    const serviceCards = page.locator(".services-grid .s-card");
     await expect(serviceCards).toHaveCount(4);
 
     // Check service card content


### PR DESCRIPTION
## Summary

**Closes #60** — Migrates the kompetanse section from bespoke `.portfolio-item` cards (empty gradient image areas) to `.s-card` with inline Heroicons SVGs:
- Prince2® — check-in-circle icon (structured methodology)
- SAFe — circular arrows icon (iterative cycles)
- DevOps og CI/CD — cog icon (automation)

Removes ~80 lines of dead CSS: `.portfolio-item`, `.portfolio-item:hover`, `.portfolio-image`, `.portfolio-image::after`, `.portfolio-content`, `.portfolio-image-gradient` and their hover/responsive variants.

**Closes #57 (partial)** — Removes the redundant `data-formspree-id="YOUR_FORM_ID"` attribute from the contact form (it was never read by `script.js`, which uses `CONFIG.formspreeEndpoint` at line 9). Single source of truth is now solely in `js/script.js`. The real form ID still needs to be provided by the team.

**#61** (trust signals) left open — requires client content and permission.

## Test plan

- [ ] Visit homepage — kompetanse section shows three cards with SVG icons (no empty gradient boxes)
- [ ] Hover over cards — consistent lift animation from `.s-card`
- [ ] No console errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)