### PR TITLE
chore(ci): use playwright docker image to speed up test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
   test:
     name: Test (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
     needs: lint
     strategy:
       fail-fast: false
@@ -41,33 +44,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-
       - name: Install dependencies
         run: npm ci --omit=optional
-
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ matrix.browser }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install ${{ matrix.browser }} --with-deps
-
-      - name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps ${{ matrix.browser }}
 
       - name: Run tests
         run: npx playwright test --project=${{ matrix.browser }} --workers=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Test (${{ matrix.browser }})
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --ipc=host
     needs: lint
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --ipc=host
+    env:
+      HOME: /root
     needs: lint
     strategy:
       fail-fast: false

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 6am on Monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/ci\\.yml$"],
+      "matchStrings": [
+        "image: mcr\\.microsoft\\.com/playwright:v(?<currentValue>[\\d.]+)-noble"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@playwright/test",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Summary
- Replaces the manual browser download/cache/`install-deps` dance with `mcr.microsoft.com/playwright:v1.58.2-noble`, the official image with all browsers pre-installed
- Removes 5 steps (get version, cache lookup, install browsers, install system deps, setup-node) per test job
- `--ipc=host` option added for Chromium shared-memory stability

## Test plan
- [x] CI passes on this PR with both chromium and firefox jobs completing faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)