### PR TITLE
chore(design-system): sync mirror CSS with live and mark as mirror

### DIFF
--- a/design-system/DESIGN-SYSTEM.md
+++ b/design-system/DESIGN-SYSTEM.md
@@ -2,6 +2,13 @@
 
 The Synkope visual system — tokens, components and usage rules — lives in this repo alongside the site it powers.
 
+> **Mirror, not source.** The canonical stylesheets are `css/tokens.css` and
+> `css/components.css` at the repo root — those are what the live site loads.
+> The copies under `design-system/css/` are a **mirror** kept only to render
+> this standalone specimen page; nothing deploys them. When you change a
+> component, edit the root `css/` files first, then copy them here so the two
+> stay in sync.
+
 ## Files
 
 | File | Role |

--- a/design-system/css/components.css
+++ b/design-system/css/components.css
@@ -217,30 +217,39 @@
 /* ---------- Bullet list ---------- */
 .s-list {
   list-style: none;
-  background: #f8fafc;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: 1.5px solid #e2e8f0;
   border-radius: var(--s-radius-lg);
-  padding: 2rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  background: #f8fafc;
+  padding: 0.5rem 0;
 }
 .s-list li {
   position: relative;
-  padding: 1rem 0 1rem 2rem;
+  padding: 0.3rem 0.75rem 0.3rem 1.5rem;
   color: var(--s-text);
   font-weight: 500;
-  line-height: var(--s-lh-body);
-  border-bottom: 1px solid #e2e8f0;
-}
-.s-list li:last-child {
-  border-bottom: none;
+  line-height: 1.45;
 }
 .s-list li::before {
-  content: "▸";
+  content: "";
   position: absolute;
-  left: 0;
-  top: 1rem;
-  color: var(--s-primary-light);
-  font-weight: bold;
-  font-size: 1.2rem;
+  left: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--s-primary);
+}
+.s-list li:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+@media (max-width: 600px) {
+  .s-list {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ---------- Reduced motion ---------- */


### PR DESCRIPTION
## What

Repository hygiene cleanup (assessment item #5).

- **Re-synced** `design-system/css/components.css` with the canonical `css/components.css`. The mirror had drifted: its `.s-list` block still used the old single-column layout while the live site moved to the compact two-column grid (PR #78). The rest of the file was already byte-identical, so this only updates the `.s-list` styling.
- **Documented the relationship** in `DESIGN-SYSTEM.md`: `css/` at the repo root is canonical and deployed; `design-system/css/` is a mirror that exists only to render the standalone specimen page, and must be re-synced after component changes.

## Also done locally (untracked, not in this PR)

- Removed the stray `--version/` directory (a botched Husky install artifact — a `_/` hook dir named `--version`).
- Removed `DS.zip` (the raw design-system export archive, already unpacked into `design-system/`).

## Testing

`npx playwright test --project=chromium` — 16/16 pass. (The changed files are not deployed and not exercised by the suite; ran per project policy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)